### PR TITLE
Fix readme skosprovider.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,4 +40,5 @@ pyramid_skosprovider is present.
     $ cd docs
     $ make html
 
-.. _skosprovider: https://github.com/OnroerendErfgoed/skosprovider
+.. [#skosprovider] https://github.com/OnroerendErfgoed/skosprovider
+


### PR DESCRIPTION
Presumably, it is meant to be a footnote.
Fixes twine build check